### PR TITLE
Simplify TimeEvolution trait

### DIFF
--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -9,9 +9,9 @@ fn main() {
     let dt = 0.01;
     let eom = model::Lorenz63::default();
     let teo = explicit::rk4(eom, dt);
-    let mut buf = explicit::RK4Buffer::new_buffer(&teo);
+    let mut buf = teo.new_buffer();
     let mut x: Array1<f64> = arr1(&[1.0, 0.0, 0.0]);
     for _ in 0..100_000_000 {
-        teo.iterate_buf(&mut x, &mut buf);
+        teo.iterate(&mut x, &mut buf);
     }
 }

--- a/examples/clv.rs
+++ b/examples/clv.rs
@@ -29,7 +29,7 @@ pub fn clv<A, S, TEO>(teo: &TEO,
                       -> Vec<(ArrayBase<S, Ix1>, Array2<A>, Array1<A::Real>)>
     where A: RealScalar,
           S: DataMut<Elem = A> + DataClone,
-          TEO: TimeEvolutionBase<S, Ix1> + TimeEvolution<A, Ix1>
+          TEO: TimeEvolution<Ix1, Scalar = A, Time = A>
 {
     let n = x0.len();
     let ts = time_series(x0, teo);

--- a/examples/lyapunov.rs
+++ b/examples/lyapunov.rs
@@ -18,10 +18,10 @@ pub fn exponents<A, S, TEO>(teo: TEO,
                             -> Array1<A>
     where A: RealScalar,
           S: DataMut<Elem = A> + DataClone,
-          TEO: TimeEvolution<A, Ix1> + TimeEvolutionBase<S, Ix1>
+          TEO: TimeEvolution<Ix1, Scalar = A, Time = A>
 {
     let n = x0.len();
-    let dur: A = AssociatedReal::inject(teo.get_dt() * into_scalar(duration as f64));
+    let dur = teo.get_dt() * into_scalar(duration as f64);
     let ts = time_series(x0, &teo);
     ts.scan(Array::eye(n), |q, x| {
         let q = jacobian(&teo, x.clone(), alpha).op_multi_mut(q);

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -71,23 +71,26 @@ impl<A, D> Diagonal<A, D>
     }
 }
 
-impl<A, Sr, D> TimeEvolutionBase<Sr, D> for Diagonal<A, D>
+impl<A, D> TimeEvolution<D> for Diagonal<A, D>
     where A: Scalar,
-          Sr: DataMut<Elem = A>,
           D: Dimension
 {
     type Scalar = A;
+    type Buffer = ();
 
-    fn iterate<'a>(&self, mut x: &'a mut ArrayBase<Sr, D>) -> &'a mut ArrayBase<Sr, D> {
+    fn new_buffer(&self) -> Self::Buffer {
+        ()
+    }
+
+    fn iterate<'a, S>(&self,
+                      mut x: &'a mut ArrayBase<S, D>,
+                      _: &mut Self::Buffer)
+                      -> &'a mut ArrayBase<S, D>
+        where S: DataMut<Elem = A>
+    {
         for (val, d) in x.iter_mut().zip(self.diag.iter()) {
             *val = *val * *d;
         }
         x
     }
-}
-
-impl<A, D> TimeEvolution<A, D> for Diagonal<A, D>
-    where A: Scalar,
-          D: Dimension
-{
 }

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -37,107 +37,84 @@ pub fn $constructor<F, Time: RealScalar>(f: F, dt: Time) -> $method<F, Time> {
     $method::new(f, dt)
 }
 
-impl<A, D, F> TimeEvolution<A, D> for $method<F, A::Real>
-    where A: Scalar,
-          D: Dimension,
-          F: Explicit<OwnedRepr<A>, D, Scalar=A, Time=A::Real>
-           + Explicit<OwnedRcRepr<A>, D, Scalar=A, Time=A::Real>
-           + for<'a> Explicit<ViewRepr<&'a mut A>, D, Scalar=A, Time=A::Real>
-{}
-
 }} // def_explicit
 
 def_explicit!(Euler, euler);
 def_explicit!(Heun, heun);
 def_explicit!(RK4, rk4);
 
-impl<A, S, D, F> TimeEvolutionBase<S, D> for Euler<F, F::Time>
-    where A: Scalar,
-          S: DataMut<Elem = A>,
-          D: Dimension,
-          F: Explicit<S, D, Time = A::Real, Scalar = A>
-{
-    type Scalar = F::Scalar;
+pub struct EulerBuffer<A, D> {
+    x: Array<A, D>,
+}
 
-    fn iterate<'a>(&self, mut x: &'a mut ArrayBase<S, D>) -> &'a mut ArrayBase<S, D> {
-        let x_ = x.to_owned();
-        let fx = self.f.rhs(x);
+impl<A, F, D> TimeEvolution<D> for Euler<F, A::Real>
+    where A: Scalar,
+          F: Explicit<D, Scalar = A, Time = A::Real>,
+          D: Dimension
+{
+    type Scalar = A;
+    type Buffer = EulerBuffer<A, D>;
+
+    fn new_buffer(&self) -> Self::Buffer {
+        EulerBuffer { x: Array::zeros(self.f.model_size()) }
+    }
+
+    fn iterate<'a, S>(&self,
+                      mut x: &'a mut ArrayBase<S, D>,
+                      mut buf: &mut Self::Buffer)
+                      -> &'a mut ArrayBase<S, D>
+        where S: DataMut<Elem = A>
+    {
+        buf.x.zip_mut_with(x, |buf, x| *buf = *x);
+        let mut fx = self.f.rhs(x);
         Zip::from(&mut *fx)
-            .and(&x_)
+            .and(&buf.x)
             .apply(|vfx, vx| { *vfx = *vx + vfx.mul_real(self.dt); });
         fx
     }
 }
 
-impl<A, S, D, F> TimeEvolutionBase<S, D> for Heun<F, F::Time>
-    where A: Scalar,
-          S: DataMut<Elem = A>,
-          D: Dimension,
-          F: Explicit<S, D, Time = A::Real, Scalar = A>
-{
-    type Scalar = F::Scalar;
+pub struct HeunBuffer<A, D> {
+    x: Array<A, D>,
+    k1: Array<A, D>,
+}
 
-    fn iterate<'a>(&self, mut x: &'a mut ArrayBase<S, D>) -> &'a mut ArrayBase<S, D> {
+impl<A, F, D> TimeEvolution<D> for Heun<F, A::Real>
+    where A: Scalar,
+          F: Explicit<D, Time = A::Real, Scalar = A>,
+          D: Dimension
+{
+    type Scalar = A;
+    type Buffer = HeunBuffer<A, D>;
+
+    fn new_buffer(&self) -> Self::Buffer {
+        HeunBuffer {
+            x: Array::zeros(self.f.model_size()),
+            k1: Array::zeros(self.f.model_size()),
+        }
+    }
+
+    fn iterate<'a, S>(&self,
+                      mut x: &'a mut ArrayBase<S, D>,
+                      mut buf: &mut HeunBuffer<A, D>)
+                      -> &'a mut ArrayBase<S, D>
+        where S: DataMut<Elem = A>
+    {
         let dt = self.dt;
         let dt_2 = self.dt * into_scalar(0.5);
         // calc
-        let x_ = x.to_owned();
+        buf.x.zip_mut_with(x, |buf, x| *buf = *x);
         let k1 = self.f.rhs(x);
-        let k1_ = k1.to_owned();
+        buf.k1.zip_mut_with(k1, |buf, k1| *buf = *k1);
         Zip::from(&mut *k1)
-            .and(&x_)
+            .and(&buf.x)
             .apply(|k1, &x_| { *k1 = k1.mul_real(dt) + x_; });
         let k2 = self.f.rhs(k1);
         Zip::from(&mut *k2)
-            .and(&x_)
-            .and(&k1_)
+            .and(&buf.x)
+            .and(&buf.k1)
             .apply(|k2, &x_, &k1_| { *k2 = x_ + (k1_ + *k2).mul_real(dt_2); });
         k2
-    }
-}
-
-impl<A, S, D, F> TimeEvolutionBase<S, D> for RK4<F, F::Time>
-    where A: Scalar,
-          S: DataMut<Elem = A>,
-          D: Dimension,
-          F: Explicit<S, D, Time = A::Real, Scalar = A>
-{
-    type Scalar = F::Scalar;
-
-    fn iterate<'a>(&self, mut x: &'a mut ArrayBase<S, D>) -> &'a mut ArrayBase<S, D> {
-        let dt = self.dt;
-        let dt_2 = self.dt * into_scalar(0.5);
-        let dt_6 = self.dt / into_scalar(6.0);
-        let x_ = x.to_owned();
-        // k1
-        let mut k1 = self.f.rhs(x);
-        let k1_ = k1.to_owned();
-        Zip::from(&mut *k1)
-            .and(&x_)
-            .apply(|k1, &x_| { *k1 = k1.mul_real(dt_2) + x_; });
-        // k2
-        let mut k2 = self.f.rhs(k1);
-        let k2_ = k2.to_owned();
-        Zip::from(&mut *k2)
-            .and(&x_)
-            .apply(|k2, &x_| { *k2 = x_ + k2.mul_real(dt_2); });
-        // k3
-        let mut k3 = self.f.rhs(k2);
-        let k3_ = k3.to_owned();
-        Zip::from(&mut *k3)
-            .and(&x_)
-            .apply(|k3, &x_| { *k3 = x_ + k3.mul_real(dt); });
-        let mut k4 = self.f.rhs(k3);
-        Zip::from(&mut *k4)
-            .and(&x_)
-            .and(&k1_)
-            .and(&k2_)
-            .and(&k3_)
-            .apply(|k4, &x_, &k1_, &k2_, &k3_| {
-                       *k4 = x_ +
-                             (k1_ + (k2_ + k3_).mul_real(into_scalar(2.0)) + *k4).mul_real(dt_6);
-                   });
-        k4
     }
 }
 
@@ -152,30 +129,32 @@ impl<A, D> RK4Buffer<A, D>
     where A: Scalar,
           D: Dimension
 {
-    pub fn new_buffer<T>(t: &T) -> RK4Buffer<A, D>
-        where T: ModelSize<D>
-    {
-        RK4Buffer {
-            x: Array::zeros(t.model_size()),
-            k1: Array::zeros(t.model_size()),
-            k2: Array::zeros(t.model_size()),
-            k3: Array::zeros(t.model_size()),
-        }
-    }
 }
 
-impl<A, S, D, F> TimeEvolutionBufferedBase<S, D, RK4Buffer<A, D>> for RK4<F, F::Time>
+impl<A, F, D> TimeEvolution<D> for RK4<F, A::Real>
     where A: Scalar,
-          S: DataMut<Elem = A>,
-          D: Dimension,
-          F: Explicit<S, D, Time = A::Real, Scalar = A>
+          F: Explicit<D, Time = A::Real, Scalar = A>,
+          D: Dimension
 {
-    type Scalar = F::Scalar;
+    type Scalar = A;
+    type Buffer = RK4Buffer<A, D>;
 
-    fn iterate_buf<'a>(&self,
-                       mut x: &'a mut ArrayBase<S, D>,
-                       mut buf: &mut RK4Buffer<A, D>)
-                       -> &'a mut ArrayBase<S, D> {
+    fn new_buffer(&self) -> Self::Buffer {
+        RK4Buffer {
+            x: Array::zeros(self.f.model_size()),
+            k1: Array::zeros(self.f.model_size()),
+            k2: Array::zeros(self.f.model_size()),
+            k3: Array::zeros(self.f.model_size()),
+        }
+    }
+
+    fn iterate<'a, S>(&self,
+                      mut x: &'a mut ArrayBase<S, D>,
+                      mut buf: &mut RK4Buffer<A, D>)
+                      -> &'a mut ArrayBase<S, D>
+        where S: DataMut<Elem = A>
+    {
+        let two = into_scalar(2.0);
         let dt = self.dt;
         let dt_2 = self.dt * into_scalar(0.5);
         let dt_6 = self.dt / into_scalar(6.0);
@@ -205,7 +184,7 @@ impl<A, S, D, F> TimeEvolutionBufferedBase<S, D, RK4Buffer<A, D>> for RK4<F, F::
             .and(&buf.k2)
             .and(&buf.k3)
             .apply(|k4, &x, &k1, &k2, &k3| {
-                       *k4 = x + (k1 + (k2 + k3).mul_real(into_scalar(2.0)) + *k4).mul_real(dt_6);
+                       *k4 = x + (k1 + (k2 + k3).mul_real(two) + *k4).mul_real(dt_6);
                    });
         k4
     }

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -12,6 +12,7 @@ macro_rules! def_explicit {
 pub struct $method<A, D, F> 
 where A: Scalar,
       D: Dimension,
+      F: Explicit<D, Scalar = A, Time = A::Real>
 {
     f: F,
     dt: A::Real,
@@ -21,7 +22,7 @@ where A: Scalar,
 impl<A, D, F> ModelSize<D> for $method<A, D, F>
 where A: Scalar,
       D: Dimension,
-      F: ModelSize<D>
+      F: Explicit<D, Scalar = A, Time = A::Real>
 {
     fn model_size(&self) -> D::Pattern {
         self.f.model_size()
@@ -30,7 +31,8 @@ where A: Scalar,
 
 impl<A, D, F> TimeStep for $method<A, D, F>
 where A: Scalar,
-      D: Dimension
+      D: Dimension,
+      F: Explicit<D, Scalar = A, Time = A::Real>
 {
     type Time = A::Real;
     fn get_dt(&self) -> Self::Time {
@@ -43,7 +45,8 @@ where A: Scalar,
 
 pub fn $constructor<A, D, F>(f: F, dt: A::Real) -> $method<A, D, F>
 where A: Scalar,
-      D: Dimension
+      D: Dimension,
+      F: Explicit<D, Scalar = A, Time = A::Real>
 {
     $method { f: f, dt: dt, phantom: PhantomData }
 }

--- a/src/model/goy_shell.rs
+++ b/src/model/goy_shell.rs
@@ -42,13 +42,13 @@ impl ModelSize<Ix1> for GoyShell {
     }
 }
 
-impl<S> SemiImplicit<S, Ix1> for GoyShell
-    where S: DataMut<Elem = c64>
-{
+impl SemiImplicit<Ix1> for GoyShell {
     type Scalar = c64;
     type Time = f64;
 
-    fn nlin<'a>(&self, mut v: &'a mut ArrayBase<S, Ix1>) -> &'a mut ArrayBase<S, Ix1> {
+    fn nlin<'a, S>(&self, mut v: &'a mut ArrayBase<S, Ix1>) -> &'a mut ArrayBase<S, Ix1>
+        where S: DataMut<Elem = c64>
+    {
         let mut am2 = c64::zero();
         let mut am1 = c64::zero();
         let mut a_0 = v[0].conj();

--- a/src/model/lorenz63.rs
+++ b/src/model/lorenz63.rs
@@ -35,13 +35,13 @@ impl ModelSize<Ix1> for Lorenz63 {
     }
 }
 
-impl<S> Explicit<S, Ix1> for Lorenz63
-    where S: DataMut<Elem = f64>
-{
+impl Explicit<Ix1> for Lorenz63 {
     type Scalar = f64;
     type Time = f64;
 
-    fn rhs<'a>(&self, mut v: &'a mut ArrayBase<S, Ix1>) -> &'a mut ArrayBase<S, Ix1> {
+    fn rhs<'a, S>(&self, mut v: &'a mut ArrayBase<S, Ix1>) -> &'a mut ArrayBase<S, Ix1>
+        where S: DataMut<Elem = f64>
+    {
         let x = v[0];
         let y = v[1];
         let z = v[2];
@@ -52,13 +52,13 @@ impl<S> Explicit<S, Ix1> for Lorenz63
     }
 }
 
-impl<S> SemiImplicit<S, Ix1> for Lorenz63
-    where S: DataMut<Elem = f64>
-{
+impl SemiImplicit<Ix1> for Lorenz63 {
     type Scalar = f64;
     type Time = f64;
 
-    fn nlin<'a>(&self, mut v: &'a mut ArrayBase<S, Ix1>) -> &'a mut ArrayBase<S, Ix1> {
+    fn nlin<'a, S>(&self, mut v: &'a mut ArrayBase<S, Ix1>) -> &'a mut ArrayBase<S, Ix1>
+        where S: DataMut<Elem = f64>
+    {
         let x = v[0];
         let y = v[1];
         let z = v[2];

--- a/src/model/lorenz96.rs
+++ b/src/model/lorenz96.rs
@@ -22,13 +22,13 @@ impl ModelSize<Ix1> for Lorenz96 {
     }
 }
 
-impl<S> Explicit<S, Ix1> for Lorenz96
-    where S: DataMut<Elem = f64>
-{
+impl Explicit<Ix1> for Lorenz96 {
     type Scalar = f64;
     type Time = f64;
 
-    fn rhs<'a>(&self, mut v: &'a mut ArrayBase<S, Ix1>) -> &'a mut ArrayBase<S, Ix1> {
+    fn rhs<'a, S>(&self, mut v: &'a mut ArrayBase<S, Ix1>) -> &'a mut ArrayBase<S, Ix1>
+        where S: DataMut<Elem = f64>
+    {
         let n = v.len();
         let v0 = v.to_owned();
         for i in 0..n {

--- a/src/model/roessler.rs
+++ b/src/model/roessler.rs
@@ -33,13 +33,13 @@ impl Roessler {
     }
 }
 
-impl<S> Explicit<S, Ix1> for Roessler
-    where S: DataMut<Elem = f64>
-{
+impl Explicit<Ix1> for Roessler {
     type Scalar = f64;
     type Time = f64;
 
-    fn rhs<'a>(&self, mut v: &'a mut ArrayBase<S, Ix1>) -> &'a mut ArrayBase<S, Ix1> {
+    fn rhs<'a, S>(&self, mut v: &'a mut ArrayBase<S, Ix1>) -> &'a mut ArrayBase<S, Ix1>
+        where S: DataMut<Elem = f64>
+    {
         let x = v[0];
         let y = v[1];
         let z = v[2];

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,60 +15,24 @@ pub trait TimeStep {
 }
 
 /// Equation of motion (Explicit)
-pub trait Explicit<S, D>: ModelSize<D>
-    where S: DataMut,
-          D: Dimension
-{
+pub trait Explicit<D: Dimension>: ModelSize<D> {
     type Scalar: Scalar;
     type Time: RealScalar;
     /// calculate right hand side (rhs) of Explicit from current state
-    fn rhs<'a>(&self, &'a mut ArrayBase<S, D>) -> &'a mut ArrayBase<S, D>;
+    fn rhs<S>(&self, &mut ArrayBase<S, D>) where S: DataMut<Elem = Self::Scalar>;
 }
 
-pub trait SemiImplicit<S, D>: ModelSize<D>
-    where S: DataMut,
-          D: Dimension
-{
+pub trait SemiImplicit<D: Dimension>: ModelSize<D> {
     type Scalar: Scalar;
     type Time: RealScalar;
     /// non-linear part of stiff equation
-    fn nlin<'a>(&self, &'a mut ArrayBase<S, D>) -> &'a mut ArrayBase<S, D>;
-}
-
-/// Time-evolution operator
-pub trait TimeEvolutionBase<S, D>: ModelSize<D> + TimeStep
-    where S: DataMut,
-          D: Dimension
-{
-    type Scalar: Scalar;
-    /// calculate next step
-    fn iterate<'a>(&self, &'a mut ArrayBase<S, D>) -> &'a mut ArrayBase<S, D>;
-}
-
-pub trait TimeEvolution<A, D>
-    : TimeEvolutionBase<OwnedRepr<A>, D, Scalar = A, Time = A::Real>
-    + TimeEvolutionBase<OwnedRcRepr<A>, D, Scalar = A, Time = A::Real>
-    + for<'a> TimeEvolutionBase<ViewRepr<&'a mut A>, D, Scalar = A, Time = A::Real>
-    where A: Scalar,
-          D: Dimension
-{
+    fn nlin<S>(&self, &mut ArrayBase<S, D>) where S: DataMut<Elem = Self::Scalar>;
 }
 
 /// Time-evolution operator with buffer
-pub trait TimeEvolutionBufferedBase<S, D, Buffer>: ModelSize<D> + TimeStep
-    where S: DataMut,
-          D: Dimension
-{
+pub trait TimeEvolution<D: Dimension>: ModelSize<D> + TimeStep {
     type Scalar: Scalar;
+    type Buffer;
     /// calculate next step
-    fn iterate_buf<'a>(&self, &'a mut ArrayBase<S, D>, &mut Buffer) -> &'a mut ArrayBase<S, D>;
-}
-
-pub trait TimeEvolutionBuffered<A, D, Buffer>
-    : TimeEvolutionBufferedBase<OwnedRepr<A>, D, Buffer, Scalar = A, Time = A::Real>
-    + TimeEvolutionBufferedBase<OwnedRcRepr<A>, D, Buffer, Scalar = A, Time = A::Real>
-    + for<'a> TimeEvolutionBufferedBase<ViewRepr<&'a mut A>, D, Buffer, Scalar = A, Time = A::Real>
-    where A: Scalar,
-          D: Dimension
-{
+    fn iterate<S>(&self, &mut ArrayBase<S, D>, &mut Buffer) where S: DataMut<Elem = Self::Scalar>;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -19,14 +19,16 @@ pub trait Explicit<D: Dimension>: ModelSize<D> {
     type Scalar: Scalar;
     type Time: RealScalar;
     /// calculate right hand side (rhs) of Explicit from current state
-    fn rhs<S>(&self, &mut ArrayBase<S, D>) where S: DataMut<Elem = Self::Scalar>;
+    fn rhs<'a, S>(&self, &'a mut ArrayBase<S, D>) -> &'a mut ArrayBase<S, D>
+        where S: DataMut<Elem = Self::Scalar>;
 }
 
 pub trait SemiImplicit<D: Dimension>: ModelSize<D> {
     type Scalar: Scalar;
     type Time: RealScalar;
     /// non-linear part of stiff equation
-    fn nlin<S>(&self, &mut ArrayBase<S, D>) where S: DataMut<Elem = Self::Scalar>;
+    fn nlin<'a, S>(&self, &'a mut ArrayBase<S, D>) -> &'a mut ArrayBase<S, D>
+        where S: DataMut<Elem = Self::Scalar>;
 }
 
 /// Time-evolution operator with buffer
@@ -36,6 +38,6 @@ pub trait TimeEvolution<D: Dimension>: ModelSize<D> + TimeStep {
     /// Generate new calculate buffer
     fn new_buffer(&self) -> Self::Buffer;
     /// calculate next step
-    fn iterate<S>(&self, &mut ArrayBase<S, D>, &mut Self::Buffer)
+    fn iterate<'a, S>(&self, &'a mut ArrayBase<S, D>, &mut Self::Buffer) -> &'a mut ArrayBase<S, D>
         where S: DataMut<Elem = Self::Scalar>;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -33,6 +33,9 @@ pub trait SemiImplicit<D: Dimension>: ModelSize<D> {
 pub trait TimeEvolution<D: Dimension>: ModelSize<D> + TimeStep {
     type Scalar: Scalar;
     type Buffer;
+    /// Generate new calculate buffer
+    fn new_buffer(&self) -> Self::Buffer;
     /// calculate next step
-    fn iterate<S>(&self, &mut ArrayBase<S, D>, &mut Buffer) where S: DataMut<Elem = Self::Scalar>;
+    fn iterate<S>(&self, &mut ArrayBase<S, D>, &mut Self::Buffer)
+        where S: DataMut<Elem = Self::Scalar>;
 }

--- a/tests/view.rs
+++ b/tests/view.rs
@@ -11,7 +11,8 @@ fn arr() {
     let eom = model::Lorenz63::default();
     let teo = explicit::euler(eom, dt);
     let mut x: Array1<f64> = arr1(&[1.0, 0.0, 0.0]);
-    teo.iterate(&mut x);
+    let mut buf = teo.new_buffer();
+    teo.iterate(&mut x, &mut buf);
 }
 
 #[test]
@@ -20,7 +21,8 @@ fn rcarr() {
     let eom = model::Lorenz63::default();
     let teo = explicit::euler(eom, dt);
     let mut x: RcArray1<f64> = rcarr1(&[1.0, 0.0, 0.0]);
-    teo.iterate(&mut x);
+    let mut buf = teo.new_buffer();
+    teo.iterate(&mut x, &mut buf);
 }
 
 #[test]
@@ -30,5 +32,6 @@ fn view_mut() {
     let teo = explicit::euler(eom, dt);
     let mut x: Array1<f64> = arr1(&[1.0, 0.0, 0.0]);
     let mut v = &mut x.view_mut();
-    teo.iterate(v);
+    let mut buf = teo.new_buffer();
+    teo.iterate(v, &mut buf);
 }


### PR DESCRIPTION
Resolve #34 
Related to #33 

- Remove `TimeEvolutionBase`
- Refine `TimeEvolutionBuffered` to new `TimeEvolution`